### PR TITLE
Correct -h example

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ converted_model_dir: PATH_TO_CONVERTED_CONTENT_MODEL_FILE/contentful_structure.j
 To display all actions use the `-h` option:
 
 ```bash
-database-exporter -h
+database-exporter -h --config-file settings.yml
 ```
 
 #### --list-tables


### PR DESCRIPTION
Even -h requires a --config-file option. If it is left out, the following error is displayed:
```
$ database-exporter -h 
/Users/me/.gem/ruby/2.2.4/gems/database-exporter-0.0.2/bin/database-exporter:9:in `<top (required)>': Missing '--config-file' argument. The correct is form: 'database-exporter --config-file PATH_TO_CONFIGURATION_FILE --action'. View README. (ArgumentError)
	from /Users/me/.gem/ruby/2.2.4/bin/database-exporter:23:in `load'
	from /Users/me/.gem/ruby/2.2.4/bin/database-exporter:23:in `<main>'
```